### PR TITLE
more fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ By default, we only wait for the final `QUIT` message to be processed (i.e. for 
 
 ## Recommendations
 
+* Ensure that both the server and the stress test are allowed to open enough file descriptors to complete the test (check the output of `ulimit` or the contents of `/proc/${pid}/limits`).
 * Test over localhost.
 * Disable ident lookup.
 * Disable connection limits.
 * Disable rate limiting.
+* Check `dmesg` for warnings about SYN flooding and adjust `net.ipv4.tcp_max_syn_backlog` as necessary

--- a/stress/events.go
+++ b/stress/events.go
@@ -44,6 +44,8 @@ func (queue EventQueue) Run(server *Server) {
 			client.Socket.Write(event.Line)
 		} else if event.Type == ETWait {
 			log.Println("ETWait events not yet implemented")
+		} else if event.Type == ETPing {
+			client.Ping()
 		} else {
 			log.Println("Got unknown event type:", event.Type)
 			spew.Dump(event)
@@ -66,6 +68,8 @@ const (
 	ETLine
 	// ETWait represents the client waiting for a specific response from the server.
 	ETWait
+	// ETPing causes the client to send a ping, then wait for the specific response
+	ETPing
 )
 
 // WaitMessage is a message that the client should wait for.

--- a/stress/server.go
+++ b/stress/server.go
@@ -3,7 +3,10 @@
 
 package stress
 
-import "sync/atomic"
+import (
+	"sync"
+	"sync/atomic"
+)
 
 // ServerConnectionDetails holds the details used to connect to the server.
 type ServerConnectionDetails struct {
@@ -15,6 +18,9 @@ type ServerConnectionDetails struct {
 type Server struct {
 	// stats
 	succeeded uint64 // align to 64-bit boundary
+
+	ClientsReadyToDisconnect sync.WaitGroup
+	ClientsFinished          sync.WaitGroup
 
 	Name string
 	Conn ServerConnectionDetails


### PR DESCRIPTION
The main thing this does is fix #4 using `sync.WaitGroup`.

There's also some refactoring that pins clients to particular `EventQueue` objects. Feel free to tell me to submit a PR that *doesn't* do this; after I did it, I realized you might have had good reasons to do it the way you did. Here's what I'm thinking:

1. The tests are most comprehensible (and most performant) if each `EventQueue` operates on a single client, without the need for local synchronization.
1. If interaction/synchronization are required, it should be possible via the server (i.e., `ETWait` will be able to do this once it's implemented).